### PR TITLE
chore(release): publish v2.1.0

### DIFF
--- a/apps/browser-simple-mdp-client/CHANGELOG.md
+++ b/apps/browser-simple-mdp-client/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @modeldriveprotocol/browser-simple-mdp-client
+
+## 2.1.0
+
+### Minor Changes
+
+- Publish the latest npm package release from `main`, including the server runtime docs routes and optional state store support shipped after `v2.0.0`.

--- a/apps/browser-simple-mdp-client/package.json
+++ b/apps/browser-simple-mdp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modeldriveprotocol/browser-simple-mdp-client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "license": "MIT",
   "description": "Simple browser client bundle for Model Drive Protocol examples and demos.",

--- a/apps/chrome-extension/CHANGELOG.md
+++ b/apps/chrome-extension/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @modeldriveprotocol/chrome-extension
+
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @modeldriveprotocol/client@2.1.0

--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modeldriveprotocol/chrome-extension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/apps/nodejs-simple-mdp-client/CHANGELOG.md
+++ b/apps/nodejs-simple-mdp-client/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @modeldriveprotocol/nodejs-simple-mdp-client
+
+## 2.1.0
+
+### Minor Changes
+
+- Publish the latest npm package release from `main`, including the server runtime docs routes and optional state store support shipped after `v2.0.0`.
+
+### Patch Changes
+
+- Updated dependencies
+  - @modeldriveprotocol/client@2.1.0

--- a/apps/nodejs-simple-mdp-client/package.json
+++ b/apps/nodejs-simple-mdp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modeldriveprotocol/nodejs-simple-mdp-client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "license": "MIT",
   "description": "Simple Node.js client for connecting local capabilities to Model Drive Protocol.",

--- a/apps/vscode-extension/CHANGELOG.md
+++ b/apps/vscode-extension/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @modeldriveprotocol/vscode-extension
+
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @modeldriveprotocol/client@2.1.0

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modeldriveprotocol/vscode-extension",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "license": "MIT",
   "displayName": "Model Drive Protocol for VS Code",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @modeldriveprotocol/client
+
+## 2.1.0
+
+### Minor Changes
+
+- Publish the latest npm package release from `main`, including the server runtime docs routes and optional state store support shipped after `v2.0.0`.
+
+### Patch Changes
+
+- Updated dependencies
+  - @modeldriveprotocol/protocol@2.1.0

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modeldriveprotocol/client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "license": "MIT",
   "description": "JavaScript client SDK and browser bundle for Model Drive Protocol.",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @modeldriveprotocol/protocol
+
+## 2.1.0
+
+### Minor Changes
+
+- Publish the latest npm package release from `main`, including the server runtime docs routes and optional state store support shipped after `v2.0.0`.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modeldriveprotocol/protocol",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "license": "MIT",
   "description": "Protocol models, messages, guards, and errors for Model Drive Protocol.",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @modeldriveprotocol/server
+
+## 2.1.0
+
+### Minor Changes
+
+- Publish the latest npm package release from `main`, including the server runtime docs routes and optional state store support shipped after `v2.0.0`.
+
+### Patch Changes
+
+- Updated dependencies
+  - @modeldriveprotocol/protocol@2.1.0

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modeldriveprotocol/server",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "license": "MIT",
   "description": "MDP server runtime and fixed MCP bridge for Model Drive Protocol.",


### PR DESCRIPTION
## Summary
- version the published npm packages to 2.1.0
- add generated changelogs for the release commit
- keep main aligned with the already-published v2.1.0 tag

## Validation
- pnpm build
- pnpm test
- release workflow 24186635731 succeeded for tag v2.1.0